### PR TITLE
Aumenta timeout da view do dropdown de produtos

### DIFF
--- a/ui/dropdown.py
+++ b/ui/dropdown.py
@@ -34,5 +34,5 @@ class ProdutoDropdown(discord.ui.Select):
 
 class ProdutoDropdownView(discord.ui.View):
     def __init__(self, bot, button_data, receitas, precos):
-        super().__init__(timeout=60)
+        super().__init__(timeout=300) # Timeout de 5 minutos
         self.add_item(ProdutoDropdown(bot, button_data, receitas, precos))


### PR DESCRIPTION
O dropdown de seleção de produtos parava de funcionar após 60 segundos, pois a view expirava. Isso causava uma falha silenciosa na interação do usuário.

Esta correção aumenta o timeout da `ProdutoDropdownView` para 300 segundos (5 minutos), dando ao usuário tempo suficiente para fazer uma seleção sem que a view expire.