### PR TITLE
Fix: Prevent button failure by simplifying dropdown callback

### DIFF
--- a/ui/dropdown.py
+++ b/ui/dropdown.py
@@ -33,18 +33,9 @@ class ProdutoDropdown(discord.ui.Select):
         # Defer the interaction to avoid "interaction failed"
         await interaction.response.defer(ephemeral=True, thinking=False)
 
-        # Update the selection in the view's state
+        # Update the selection in the view's state.
+        # The view will be visually updated by the AdicionarItem button later.
         self.view.selecoes[self.index] = self.values[0]
-
-        # Rebuild the entire view to reflect the new state
-        self.view.build_view()
-
-        # Edit the original message with the updated view
-        try:
-            await interaction.message.edit(view=self.view)
-        except discord.errors.NotFound:
-            # This can happen if the original message was deleted
-            pass
 
 
 class ProdutoDropdownView(discord.ui.View):


### PR DESCRIPTION
Reverts the `ProdutoDropdown` callback to only update the view's internal state (`self.view.selecoes`) and not rebuild the entire view.

The previous implementation, which rebuilt the view on every dropdown selection, caused subsequent button interactions (like 'Add Item') to fail silently. This simplified approach ensures the button remains responsive. The visual update of the view is now handled exclusively by the 'Add Item' button's callback, which was the original, correct behavior.