### PR TITLE
Feat: Tratar Farelo de Minério como material base

### DIFF
--- a/cogs/calculator.py
+++ b/cogs/calculator.py
@@ -86,7 +86,8 @@ def calcular_materiais(item_nome, quantidade_desejada, receitas, acumulador=None
     if acumulador is None:
         acumulador = defaultdict(float)
 
-    if item_nome not in receitas:
+    # Condição para tratar 'Farelo de Minério' como matéria-prima
+    if item_nome not in receitas or item_nome == "Farelo de Minério":
         acumulador[item_nome] += quantidade_desejada
         return acumulador
 

--- a/cogs/encomendas.py
+++ b/cogs/encomendas.py
@@ -133,6 +133,10 @@ def gerar_blocos_de_rateio(item_raiz, quantidade_desejada, receitas):
     # 3. Gerar os blocos de texto na ordem correta
     blocos = []
     for item in ordem_de_craft:
+        # Pula a geração do bloco de rateio para 'Farelo de Minério'
+        if item == "Farelo de Minério":
+            continue
+
         if item in necessidades and necessidades[item] > 0:
             qtd = math.ceil(necessidades[item])
             bloco_str = _formatar_bloco_individual(item, qtd, receitas)


### PR DESCRIPTION
Modifica a lógica de cálculo e de exibição para tratar 'Farelo de Minério' como um material base em vez de um item intermediário a ser fabricado.

- Em `cogs/calculator.py`, a função `calcular_materiais` agora para sua recursão ao encontrar 'Farelo de Minério', incluindo-o na lista final de materiais necessários.
- Em `cogs/encomendas.py`, a função `gerar_blocos_de_rateio` agora pula a criação de um bloco de instruções de fabricação para 'Farelo de Minério'.

Isso atende ao requisito de listar a quantidade total de 'Farelo de Minério' necessária, mas sem detalhar como fabricá-lo.